### PR TITLE
Update sphinx base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sphinxdoc/sphinx:2.4.4
+FROM sphinxdoc/sphinx:3.4.1
 
 LABEL "maintainer"="Ammar Askar <ammar@ammaraskar.com>"
 


### PR DESCRIPTION
This just applies changes in https://github.com/ammaraskar/sphinx-action/pull/21, which fixes the issue in https://github.com/ammaraskar/sphinx-action/issues/33, allowing installation of latexmk. Recent builds fail otherwise when using `ammaraskar/sphinx-action@master`.